### PR TITLE
Feat/export csv

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22,6 +22,7 @@
         "clsx": "^2.1.1",
         "date-fns": "^3.6.0",
         "dotenv": "^16.4.5",
+        "export-to-csv": "^1.3.0",
         "lucide-react": "^0.407.0",
         "pagedone": "^1.1.2",
         "react": "^18.3.1",
@@ -4293,6 +4294,14 @@
       },
       "engines": {
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/export-to-csv": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/export-to-csv/-/export-to-csv-1.3.0.tgz",
+      "integrity": "sha512-msPjbfozZdYzDghAEKmCVH5veMeKHNacplE6noXvGiA8AeV1qa/SOxp6JXDjF9R8Kf6v3ypI6jskiY19dkhZeA==",
+      "engines": {
+        "node": "^v12.20.0 || >=v14.13.0"
       }
     },
     "node_modules/fast-deep-equal": {

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "clsx": "^2.1.1",
     "date-fns": "^3.6.0",
     "dotenv": "^16.4.5",
+    "export-to-csv": "^1.3.0",
     "lucide-react": "^0.407.0",
     "pagedone": "^1.1.2",
     "react": "^18.3.1",

--- a/src/components/QuarantineTableForm.tsx
+++ b/src/components/QuarantineTableForm.tsx
@@ -1,6 +1,6 @@
 import { useState } from 'react';
 
-const QuarantineTableFormTableForm = ({handleAIButton, quarantineTableSelector}) => {
+const QuarantineTableFormTableForm = ({handleAIButton, quarantineTableSelector, exportToCSV}) => {
   const [showUniqueErrors, setShowUniqueErrors] = useState(false);
   const [timeRange, setTimeRange] = useState('1h');
   //const [startDate, setStartDate] = useState('');
@@ -14,7 +14,7 @@ const QuarantineTableFormTableForm = ({handleAIButton, quarantineTableSelector})
     query += 'error_type, error_message, raw_data, original_table, insertion_timestamp ';
     query += 'FROM error_table ';
     
-    let whereConditions = [];
+    const whereConditions = [];
 
     // Time range condition
     if (formData.timeRange !== 'all') {
@@ -132,7 +132,7 @@ const QuarantineTableFormTableForm = ({handleAIButton, quarantineTableSelector})
             </select>
             <span className="text-sm text-gray-700">entries</span>
           </div>
-          <div>
+          <div className="flex gap-3">
             <button
               type="submit"
               className="px-4 py-2 bg-indigo-600 text-white rounded-md hover:bg-indigo-800 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2"
@@ -140,10 +140,17 @@ const QuarantineTableFormTableForm = ({handleAIButton, quarantineTableSelector})
               Apply Filters
             </button>
             <button
-              className="ml-3 bg-orange-400 hover:bg-amber-600 text-white py-2 px-4 rounded-md"
+              className="bg-orange-400 hover:bg-amber-600 text-white py-2 px-4 rounded-md"
               //onClick={handleAIButton}
             >
               AI Error Analysis
+            </button>
+            <button
+              className="bg-green-600 hover:bg-green-700 text-white py-2 px-4 rounded-md"
+              onClick={exportToCSV}
+              type="button"
+            >
+              Export CSV
             </button>
           </div>
         </div>

--- a/src/components/QuarantineTablePage.tsx
+++ b/src/components/QuarantineTablePage.tsx
@@ -3,7 +3,8 @@ import { columns } from "./dataTable/columns"
 import fetchOpenAIOutput from "../utils/fetchOpenAiOuput";
 import QuarantineTableForm from "./QuarantineTableForm";
 import { useEffect, useRef, useState } from "react";
-import queryService from '../services/api'
+import queryService from '../services/api';
+import { mkConfig, generateCsv, download } from 'export-to-csv';
 
 const QuarantineTablePage = () => {
   const [selectedInfo, setSelectedInfo] = useState({
@@ -63,6 +64,18 @@ const QuarantineTablePage = () => {
       // alert('You have no quarantine tables')
     }
   }, [selectedInfo.table]);
+
+  const csvConfig = mkConfig({
+    fieldSeparator: ',',
+    filename: 'sql_export',
+    decimalSeparator: '.',
+    useKeysAsHeaders: true,
+  });
+
+  const exportToCSV = () => {
+    const csv = generateCsv(csvConfig)(tableInfo.rows);
+    download(csvConfig)(csv);
+  };
 
   const handleTableSelect = async (e: React.SyntheticEvent) => {
     const table = e.target.value;
@@ -184,7 +197,7 @@ const QuarantineTablePage = () => {
     <>
       <div className="p-8 w-full">
         <div className="max-w-screen mx-auto bg-white shadow-lg rounded-lg p-6 border border-gray-200">
-          <QuarantineTableForm handleAIButton={handleAIButton} quarantineTableSelector={quarantineTableSelector} />
+          <QuarantineTableForm handleAIButton={handleAIButton} quarantineTableSelector={quarantineTableSelector} exportToCSV={exportToCSV} />
           <div className="grid grid-cols-1 gap-4">
             <div>
               <label

--- a/src/components/SQLConsole.tsx
+++ b/src/components/SQLConsole.tsx
@@ -4,15 +4,11 @@ import { DataTable } from "./dataTable/DataTable";
 import { columns } from "./dataTable/columns"
 import { useIntegration } from "../contexts/IntegrationContext";
 import { useLocation } from "react-router-dom";
-
 import CodeMirror from '@uiw/react-codemirror';
-// import { javascript } from '@codemirror/lang-javascript';
 import { sql } from '@codemirror/lang-sql';
-// import { StreamLanguage } from '@codemirror/language';
 import { createTheme } from '@uiw/codemirror-themes';
 import { tags as t } from '@lezer/highlight';
-
-
+import { mkConfig, generateCsv, download } from 'export-to-csv';
 
 const SQLConsole = () => {
   const location = useLocation()
@@ -81,6 +77,18 @@ const SQLConsole = () => {
 
     fetchTableData();
   }, [selectedInfo.database, selectedInfo.table]);
+
+  const csvConfig = mkConfig({
+    fieldSeparator: ',',
+    filename: 'sql_export',
+    decimalSeparator: '.',
+    useKeysAsHeaders: true,
+  });
+
+  const exportToCSV = () => {
+    const csv = generateCsv(csvConfig)(tableInfo.rows);
+    download(csvConfig)(csv);
+  };
 
   const handleDatabaseSelect = (e: React.ChangeEvent<HTMLSelectElement>) => {
     const database = e.target.value
@@ -175,8 +183,6 @@ const SQLConsole = () => {
 
   return (
     <>
-      {/* <CodeMirror value={'javascript'} height="200px" extensions={[sql({ sql: true })]} /> */}
-
       <div className="p-8 w-full">
         <div className="max-w-screen mx-auto bg-white shadow-lg rounded-lg p-6 border border-gray-200">
           <div className="grid grid-cols-4 gap-4 mb-6">
@@ -214,12 +220,19 @@ const SQLConsole = () => {
                 {tableOptions}
               </select>
             </div>
-            <div className="col-span-2 flex justify-end items-start">
+            <div className="col-span-2 flex justify-end items-start space-x-2">
               <button
                 className="bg-indigo-600 hover:bg-indigo-700 text-white py-2 px-4 rounded-md"
                 onClick={handleSelectQuery}
               >
                 Run
+              </button>
+              <button
+                className="bg-green-600 hover:bg-green-700 text-white py-2 px-4 rounded-md"
+                onClick={exportToCSV}
+                disabled={tableInfo.rows.length === 0}
+              >
+                Export CSV
               </button>
             </div>
           </div>
@@ -231,16 +244,6 @@ const SQLConsole = () => {
               >
                 SQL Queries
               </label>
-              {/* <textarea
-                id="sql-queries"
-                name="sql-queries"
-                rows="4"
-                className="mt-1 block w-full pl-3 pr-10 py-2 text-base border border-gray-300 focus:outline-none focus:ring-indigo-500 focus:border-indigo-500 sm:text-sm rounded-md"
-                placeholder="Write query..."
-                value={query}
-                onChange={handleQueryText}
-                onKeyDown={handleKeyDown}
-              ></textarea> */}
               <CodeMirror
                 id="sql-queries"
                 placeholder="Write query..."
@@ -260,7 +263,9 @@ const SQLConsole = () => {
                 Table Visual <span className="text-gray-500">- {tableInfo.row_count} rows</span>
               </label>
               <div id="table-visual">
-                {tableInfo.rows.length !== 0 && tableInfo.cols.length !== 0 && <DataTable columns={formattedColumns} data={tableInfo.rows} ></DataTable>}
+                {tableInfo.rows.length !== 0 && tableInfo.cols.length !== 0 && (
+                  <DataTable columns={formattedColumns} data={tableInfo.rows} />
+                )}
               </div>
             </div>
           </div>


### PR DESCRIPTION
## Overview
Use tanstack's innate functionality to add export to CSV buttons to quarantine table and sql dashboard pages

## Changes
- Add exportToCSV function
- Set the default filename to `sql_export`

## Notes for Reviewers
- Some duplicate logic, but it was very short so we decided not to extract it out